### PR TITLE
Add support for firefox

### DIFF
--- a/examples/vue-app/src/App.vue
+++ b/examples/vue-app/src/App.vue
@@ -286,7 +286,7 @@ export default {
       )
     },
     logout() {
-      window.torus.cleanUp().then(() => (this.publicAddress = ''))
+      window.torus.logout().then(() => (this.publicAddress = ''))
     },
     changeProvider() {
       window.torus.setProvider({ host: 'ropsten' }).then(this.console).catch(this.console)

--- a/src/utils.js
+++ b/src/utils.js
@@ -2,6 +2,7 @@ import log from 'loglevel'
 import { serializeError } from 'eth-json-rpc-errors'
 import EventEmitter from 'events'
 import SafeEventEmitter from 'safe-event-emitter'
+import randomId from '@chaitanyapotti/random-id'
 
 import config from './config'
 
@@ -113,4 +114,12 @@ export const makeThenable = (obj, prop) => {
   Object.defineProperty(obj, 'finally', { ...defineOpts, value: Promise.prototype.finally })
 
   return obj
+}
+
+export const getPreopenInstanceId = () => {
+  return isFirefox() ? undefined : randomId()
+}
+
+export const isFirefox = () => {
+  return navigator.userAgent.toLowerCase().includes('firefox')
 }


### PR DESCRIPTION
In case of firefox, the users now have to unblock popups to make torus work.
This PR removes the support for pre-opening popups from embed for firefox only.