### PR TITLE
Network refactor

### DIFF
--- a/src/embed.js
+++ b/src/embed.js
@@ -106,8 +106,8 @@ class Torus {
     enabledVerifiers = defaultVerifiers,
     network = {
       host: 'mainnet',
-      chainId: 1,
-      networkName: 'mainnet',
+      chainId: null,
+      networkName: '',
     },
     showTorusButton = true,
     integrity = {
@@ -764,7 +764,7 @@ class Torus {
     }
   }
 
-  setProvider({ host = 'mainnet', chainId = 1, networkName = 'mainnet' } = {}) {
+  setProvider({ host = 'mainnet', chainId = null, networkName = '' } = {}) {
     return new Promise((resolve, reject) => {
       const providerChangeStream = this.communicationMux.getStream('provider_change')
       const handler = (chunk) => {
@@ -798,7 +798,7 @@ class Torus {
     })
   }
 
-  _setProvider({ host = 'mainnet', chainId = 1, networkName = 'mainnet' } = {}) {
+  _setProvider({ host = 'mainnet', chainId = null, networkName = '' } = {}) {
     return new Promise((resolve, reject) => {
       if (!this.isInitalized) {
         const providerChangeStream = this.communicationMux.getStream('provider_change')


### PR DESCRIPTION
The following changes have been made in this PR:
- Don't set default params for network name and chain id
By setting default params, we are allowing custom networks to be of { host: 'rinkeby', name: 'main ethereum network', chainId: 1 } which is invalid. If not set, they'll be filled in actions.js of torus-website