### PR TITLE
Integrity checks

### DIFF
--- a/examples/vue-app/package-lock.json
+++ b/examples/vue-app/package-lock.json
@@ -1146,28 +1146,193 @@
       }
     },
     "@toruslabs/fetch-node-details": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/@toruslabs/fetch-node-details/-/fetch-node-details-2.2.1.tgz",
-      "integrity": "sha512-nY2Jzguz33iWVbmNmn+N/oj5+KosTHJarRUMP23P/cikU56TK3oqoYKC/pUdYD+dy4EwgtllxLHUEP3JQn2Xnw==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@toruslabs/fetch-node-details/-/fetch-node-details-2.2.2.tgz",
+      "integrity": "sha512-ojEgabJrhCXu6F4Z48q/IsmSaJ0AT+e4TYBS/ibaWFlIFXC2alJ2hvVyGz3h9xv/xn4/fkc+bMouLnhyYr71AA==",
       "requires": {
-        "web3-eth-contract": "^1.2.6",
-        "web3-utils": "^1.2.6"
+        "web3-eth-contract": "^1.2.7",
+        "web3-utils": "^1.2.7"
+      },
+      "dependencies": {
+        "eth-lib": {
+          "version": "0.2.7",
+          "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
+          "integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=",
+          "requires": {
+            "bn.js": "^4.11.6",
+            "elliptic": "^6.4.0",
+            "xhr-request-promise": "^0.1.2"
+          }
+        },
+        "web3-core": {
+          "version": "1.2.7",
+          "resolved": "https://registry.npmjs.org/web3-core/-/web3-core-1.2.7.tgz",
+          "integrity": "sha512-QA0MTae0gXcr3KHe3cQ4x56+Wh43ZKWfMwg1gfCc3NNxPRM1jJ8qudzyptCAUcxUGXWpDG8syLIn1APDz5J8BQ==",
+          "requires": {
+            "@types/bn.js": "^4.11.4",
+            "@types/node": "^12.6.1",
+            "bignumber.js": "^9.0.0",
+            "web3-core-helpers": "1.2.7",
+            "web3-core-method": "1.2.7",
+            "web3-core-requestmanager": "1.2.7",
+            "web3-utils": "1.2.7"
+          }
+        },
+        "web3-core-helpers": {
+          "version": "1.2.7",
+          "resolved": "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.2.7.tgz",
+          "integrity": "sha512-bdU++9QATGeCetVrMp8pV97aQtVkN5oLBf/TWu/qumC6jK/YqrvLlBJLdwbz0QveU8zOSap6GCvJbqKvmmbV2A==",
+          "requires": {
+            "underscore": "1.9.1",
+            "web3-eth-iban": "1.2.7",
+            "web3-utils": "1.2.7"
+          }
+        },
+        "web3-core-method": {
+          "version": "1.2.7",
+          "resolved": "https://registry.npmjs.org/web3-core-method/-/web3-core-method-1.2.7.tgz",
+          "integrity": "sha512-e1TI0QUnByDMbQ8QHwnjxfjKw0LIgVRY4TYrlPijET9ebqUJU1HCayn/BHIMpV6LKyR1fQj9EldWyT64wZQXkg==",
+          "requires": {
+            "underscore": "1.9.1",
+            "web3-core-helpers": "1.2.7",
+            "web3-core-promievent": "1.2.7",
+            "web3-core-subscriptions": "1.2.7",
+            "web3-utils": "1.2.7"
+          }
+        },
+        "web3-core-promievent": {
+          "version": "1.2.7",
+          "resolved": "https://registry.npmjs.org/web3-core-promievent/-/web3-core-promievent-1.2.7.tgz",
+          "integrity": "sha512-jNmsM/czCeMGQqKKwM9/HZVTJVIF96hdMVNN/V9TGvp+EEE7vDhB4pUocDnc/QF9Z/5QFBCVmvNWttlRgZmU0A==",
+          "requires": {
+            "eventemitter3": "3.1.2"
+          }
+        },
+        "web3-core-requestmanager": {
+          "version": "1.2.7",
+          "resolved": "https://registry.npmjs.org/web3-core-requestmanager/-/web3-core-requestmanager-1.2.7.tgz",
+          "integrity": "sha512-HJb/txjHixu1dxIebiZQKBoJCaNu4gsh7mq/uj6Z/w6tIHbybL90s/7ADyMED353yyJ2tDWtYJqeMVAR+KtdaA==",
+          "requires": {
+            "underscore": "1.9.1",
+            "web3-core-helpers": "1.2.7",
+            "web3-providers-http": "1.2.7",
+            "web3-providers-ipc": "1.2.7",
+            "web3-providers-ws": "1.2.7"
+          }
+        },
+        "web3-core-subscriptions": {
+          "version": "1.2.7",
+          "resolved": "https://registry.npmjs.org/web3-core-subscriptions/-/web3-core-subscriptions-1.2.7.tgz",
+          "integrity": "sha512-W/CzQYOUawdMDvkgA/fmLsnG5aMpbjrs78LZMbc0MFXLpH3ofqAgO2by4QZrrTShUUTeWS0ZuEkFFL/iFrSObw==",
+          "requires": {
+            "eventemitter3": "3.1.2",
+            "underscore": "1.9.1",
+            "web3-core-helpers": "1.2.7"
+          }
+        },
+        "web3-eth-abi": {
+          "version": "1.2.7",
+          "resolved": "https://registry.npmjs.org/web3-eth-abi/-/web3-eth-abi-1.2.7.tgz",
+          "integrity": "sha512-4FnlT1q+D0XBkxSMXlIb/eG337uQeMaUdtVQ4PZ3XzxqpcoDuMgXm4o+3NRxnWmr4AMm6QKjM+hcC7c0mBKcyg==",
+          "requires": {
+            "ethers": "4.0.0-beta.3",
+            "underscore": "1.9.1",
+            "web3-utils": "1.2.7"
+          }
+        },
+        "web3-eth-contract": {
+          "version": "1.2.7",
+          "resolved": "https://registry.npmjs.org/web3-eth-contract/-/web3-eth-contract-1.2.7.tgz",
+          "integrity": "sha512-uW23Y0iL7XroRNbf9fWZ1N6OYhEYTJX8gTuYASuRnpYrISN5QGiQML6pq/NCzqypR1bl5E0fuINZQSK/xefIVw==",
+          "requires": {
+            "@types/bn.js": "^4.11.4",
+            "underscore": "1.9.1",
+            "web3-core": "1.2.7",
+            "web3-core-helpers": "1.2.7",
+            "web3-core-method": "1.2.7",
+            "web3-core-promievent": "1.2.7",
+            "web3-core-subscriptions": "1.2.7",
+            "web3-eth-abi": "1.2.7",
+            "web3-utils": "1.2.7"
+          }
+        },
+        "web3-eth-iban": {
+          "version": "1.2.7",
+          "resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.2.7.tgz",
+          "integrity": "sha512-2NrClz1PoQ3nSJBd+91ylCOVga9qbTxjRofq/oSCoHVAEvz3WZyttx9k5DC+0rWqwJF1h69ufFvdHAAlmN/4lg==",
+          "requires": {
+            "bn.js": "4.11.8",
+            "web3-utils": "1.2.7"
+          }
+        },
+        "web3-providers-http": {
+          "version": "1.2.7",
+          "resolved": "https://registry.npmjs.org/web3-providers-http/-/web3-providers-http-1.2.7.tgz",
+          "integrity": "sha512-vazGx5onuH/zogrwkUaLFJwFcJ6CckP65VFSHoiV+GTQdkOqgoDIha7StKkslvDz4XJ2FuY/zOZHbtuOYeltXQ==",
+          "requires": {
+            "web3-core-helpers": "1.2.7",
+            "xhr2-cookies": "1.1.0"
+          }
+        },
+        "web3-providers-ipc": {
+          "version": "1.2.7",
+          "resolved": "https://registry.npmjs.org/web3-providers-ipc/-/web3-providers-ipc-1.2.7.tgz",
+          "integrity": "sha512-/zc0y724H2zbkV4UbGGMhsEiLfafjagIzfrsWZnyTZUlSB0OGRmmFm2EkLJAgtXrLiodaHHyXKM0vB8S24bxdA==",
+          "requires": {
+            "oboe": "2.1.4",
+            "underscore": "1.9.1",
+            "web3-core-helpers": "1.2.7"
+          }
+        },
+        "web3-providers-ws": {
+          "version": "1.2.7",
+          "resolved": "https://registry.npmjs.org/web3-providers-ws/-/web3-providers-ws-1.2.7.tgz",
+          "integrity": "sha512-b5XzqDpRkNVe6MFs5K6iqOEyjQikHtg3KuU2/ClCDV37hm0WN4xCRVMC0LwegulbDXZej3zT9+1CYzGaGFREzA==",
+          "requires": {
+            "@web3-js/websocket": "^1.0.29",
+            "eventemitter3": "^4.0.0",
+            "underscore": "1.9.1",
+            "web3-core-helpers": "1.2.7"
+          },
+          "dependencies": {
+            "eventemitter3": {
+              "version": "4.0.4",
+              "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.4.tgz",
+              "integrity": "sha512-rlaVLnVxtxvoyLsQQFBx53YmXHDxRIzzTLbdfxqi4yocpSjAxXwkU0cScM5JgSKMqEhrZpnvQ2D9gjylR0AimQ=="
+            }
+          }
+        },
+        "web3-utils": {
+          "version": "1.2.7",
+          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.7.tgz",
+          "integrity": "sha512-FBh/CPJND+eiPeUF9KVbTyTZtXNWxPWtByBaWS6e2x4ACazPX711EeNaZaChIOGSLGe6se2n7kg6wnawe/MjuQ==",
+          "requires": {
+            "bn.js": "4.11.8",
+            "eth-lib": "0.2.7",
+            "ethereum-bloom-filters": "^1.0.6",
+            "ethjs-unit": "0.1.6",
+            "number-to-bn": "1.7.0",
+            "randombytes": "^2.1.0",
+            "underscore": "1.9.1",
+            "utf8": "3.0.0"
+          }
+        }
       }
     },
     "@toruslabs/torus-embed": {
-      "version": "file:../../toruslabs-torus-embed-1.4.0.tgz",
-      "integrity": "sha512-KlQ4cRKKeYC3uqTFFBjU6R1jtYvFMESvIzi6EyGXPUQOeprQw0eHTplkXOuT1QtdH+3BdaT3qUr9wQL0qkHpfQ==",
+      "version": "file:../../toruslabs-torus-embed-1.4.3.tgz",
+      "integrity": "sha512-u6KrJJhg1XuuJ2NsbTrPlBCAr92YOL15rwCkpcgd1yqW5YqPETQDAMdf4rjymjKBMnswEO1dNFJyxOyt+ufBPQ==",
       "requires": {
         "@chaitanyapotti/random-id": "^1.0.3",
-        "@toruslabs/fetch-node-details": "^2.2.1",
-        "@toruslabs/torus.js": "^2.1.2",
+        "@toruslabs/fetch-node-details": "^2.2.2",
+        "@toruslabs/torus.js": "^2.1.3",
         "create-hash": "^1.2.0",
         "deepmerge": "^4.2.2",
         "eth-json-rpc-errors": "^2.0.2",
         "fast-deep-equal": "^3.1.1",
         "json-rpc-engine": "^5.1.8",
         "json-rpc-middleware-stream": "^2.1.1",
-        "loglevel": "^1.6.7",
+        "loglevel": "^1.6.8",
         "obj-multiplex": "^1.0.0",
         "obs-store": "^4.0.3",
         "post-message-stream": "^3.0.0",
@@ -1176,6 +1341,10 @@
         "web3": "^0.20.7"
       },
       "dependencies": {
+        "bignumber.js": {
+          "version": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
+          "from": "git+https://github.com/frozeman/bignumber.js-nolookahead.git"
+        },
         "deepmerge": {
           "version": "4.2.2",
           "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
@@ -1185,6 +1354,11 @@
           "version": "3.1.1",
           "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",
           "integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA=="
+        },
+        "loglevel": {
+          "version": "1.6.8",
+          "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.6.8.tgz",
+          "integrity": "sha512-bsU7+gc9AJ2SqpzxwU3+1fedl8zAntbtC5XYlt3s2j1hJcn2PsXSmgN8TaLG/J1/2mod4+cE/3vNL70/c1RNCA=="
         },
         "utf8": {
           "version": "2.1.2",
@@ -1206,16 +1380,16 @@
       }
     },
     "@toruslabs/torus.js": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@toruslabs/torus.js/-/torus.js-2.1.2.tgz",
-      "integrity": "sha512-5H9+nuD6eDwQLPPXCvzAzYmDmW7y839NWZ0MkGpyOBm7rwRgbTRvdVo58QaMF0QdqeYqAjE44XAkR1wceVX6VQ==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@toruslabs/torus.js/-/torus.js-2.1.3.tgz",
+      "integrity": "sha512-o41OSv4Rvw0dTe3XU29U1Xqd2LffsPiy1QpvJhPpu15/b1Y6TvCYxz/v9P1c+bygmpT+pMkB9jYzYFh/eyUybQ==",
       "requires": {
         "bn.js": "^5.1.1",
         "eccrypto": "^1.1.3",
         "elliptic": "^6.5.2",
         "json-stable-stringify": "^1.0.1",
-        "loglevel": "^1.6.7",
-        "web3-utils": "^1.2.6"
+        "loglevel": "^1.6.8",
+        "web3-utils": "^1.2.7"
       },
       "dependencies": {
         "bn.js": {
@@ -1235,6 +1409,50 @@
             "inherits": "^2.0.1",
             "minimalistic-assert": "^1.0.0",
             "minimalistic-crypto-utils": "^1.0.0"
+          },
+          "dependencies": {
+            "bn.js": {
+              "version": "4.11.8",
+              "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
+              "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
+            }
+          }
+        },
+        "eth-lib": {
+          "version": "0.2.7",
+          "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
+          "integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=",
+          "requires": {
+            "bn.js": "^4.11.6",
+            "elliptic": "^6.4.0",
+            "xhr-request-promise": "^0.1.2"
+          },
+          "dependencies": {
+            "bn.js": {
+              "version": "4.11.8",
+              "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
+              "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
+            }
+          }
+        },
+        "loglevel": {
+          "version": "1.6.8",
+          "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.6.8.tgz",
+          "integrity": "sha512-bsU7+gc9AJ2SqpzxwU3+1fedl8zAntbtC5XYlt3s2j1hJcn2PsXSmgN8TaLG/J1/2mod4+cE/3vNL70/c1RNCA=="
+        },
+        "web3-utils": {
+          "version": "1.2.7",
+          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.7.tgz",
+          "integrity": "sha512-FBh/CPJND+eiPeUF9KVbTyTZtXNWxPWtByBaWS6e2x4ACazPX711EeNaZaChIOGSLGe6se2n7kg6wnawe/MjuQ==",
+          "requires": {
+            "bn.js": "4.11.8",
+            "eth-lib": "0.2.7",
+            "ethereum-bloom-filters": "^1.0.6",
+            "ethjs-unit": "0.1.6",
+            "number-to-bn": "1.7.0",
+            "randombytes": "^2.1.0",
+            "underscore": "1.9.1",
+            "utf8": "3.0.0"
           },
           "dependencies": {
             "bn.js": {
@@ -2516,8 +2734,9 @@
       "dev": true
     },
     "bignumber.js": {
-      "version": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
-      "from": "git+https://github.com/frozeman/bignumber.js-nolookahead.git"
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.0.tgz",
+      "integrity": "sha512-t/OYhhJ2SD+YGBQcjY8GzzDHEk9f3nerxjtfa6tlMXfe7frs/WozhvCNoGvpM0P3bNf3Gq5ZRMlGr5f3r4/N8A=="
     },
     "binary-extensions": {
       "version": "1.13.1",
@@ -2603,7 +2822,7 @@
         },
         "ms": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "resolved": "https://registry.npm.taobao.org/ms/download/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
         }
       }
@@ -3390,7 +3609,7 @@
     },
     "color-name": {
       "version": "1.1.3",
-      "resolved": "https://registry.npm.taobao.org/color-name/download/color-name-1.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
       "dev": true
     },
@@ -4001,7 +4220,7 @@
     },
     "de-indent": {
       "version": "1.0.2",
-      "resolved": "https://registry.npm.taobao.org/de-indent/download/de-indent-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/de-indent/-/de-indent-1.0.2.tgz",
       "integrity": "sha1-sgOOhG3DO6pXlhKNCAS0VbjB4h0=",
       "dev": true
     },
@@ -4402,7 +4621,7 @@
     },
     "des.js": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.0.tgz",
+      "resolved": "https://registry.npm.taobao.org/des.js/download/des.js-1.0.0.tgz",
       "integrity": "sha1-wHTS4qpqipoH29YfmhXCzYPsjsw=",
       "requires": {
         "inherits": "^2.0.1",
@@ -4844,7 +5063,7 @@
     },
     "escape-string-regexp": {
       "version": "1.0.5",
-      "resolved": "https://registry.npm.taobao.org/escape-string-regexp/download/escape-string-regexp-1.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
       "dev": true
     },
@@ -5486,7 +5705,7 @@
         },
         "ms": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "resolved": "https://registry.npm.taobao.org/ms/download/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
         }
       }
@@ -5762,7 +5981,7 @@
         },
         "ms": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "resolved": "https://registry.npm.taobao.org/ms/download/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
         }
       }
@@ -6757,7 +6976,7 @@
     },
     "has-flag": {
       "version": "3.0.0",
-      "resolved": "https://registry.npm.taobao.org/has-flag/download/has-flag-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
       "dev": true
     },
@@ -8206,7 +8425,8 @@
     "loglevel": {
       "version": "1.6.7",
       "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.6.7.tgz",
-      "integrity": "sha512-cY2eLFrQSAfVPhCgH1s7JI73tMbg9YC3v3+ZHVW67sBS7UxWzNEk/ZBbSfLykBWHp33dqqtOv82gjhKEi81T/A=="
+      "integrity": "sha512-cY2eLFrQSAfVPhCgH1s7JI73tMbg9YC3v3+ZHVW67sBS7UxWzNEk/ZBbSfLykBWHp33dqqtOv82gjhKEi81T/A==",
+      "dev": true
     },
     "loose-envify": {
       "version": "1.4.0",
@@ -8700,7 +8920,7 @@
       "dependencies": {
         "minimist": {
           "version": "0.0.8",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "resolved": "https://registry.npm.taobao.org/minimist/download/minimist-0.0.8.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fminimist%2Fdownload%2Fminimist-0.0.8.tgz",
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
         }
       }
@@ -11038,7 +11258,7 @@
           "dependencies": {
             "ms": {
               "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+              "resolved": "https://registry.npm.taobao.org/ms/download/ms-2.0.0.tgz",
               "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
             }
           }
@@ -11460,7 +11680,7 @@
     },
     "source-map": {
       "version": "0.5.7",
-      "resolved": "https://registry.npm.taobao.org/source-map/download/source-map-0.5.7.tgz",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
       "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
       "dev": true
     },
@@ -12243,7 +12463,7 @@
     },
     "to-fast-properties": {
       "version": "2.0.0",
-      "resolved": "https://registry.npm.taobao.org/to-fast-properties/download/to-fast-properties-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
       "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
       "dev": true
     },

--- a/examples/vue-app/package.json
+++ b/examples/vue-app/package.json
@@ -8,7 +8,7 @@
     "lint": "vue-cli-service lint"
   },
   "dependencies": {
-    "@toruslabs/torus-embed": "file:../../toruslabs-torus-embed-1.4.0.tgz",
+    "@toruslabs/torus-embed": "file:../../toruslabs-torus-embed-1.4.3.tgz",
     "core-js": "^3.6.4",
     "eth-sig-util": "^2.5.3",
     "human-standard-token-abi": "^2.0.0",

--- a/examples/vue-app/src/App.vue
+++ b/examples/vue-app/src/App.vue
@@ -95,65 +95,70 @@ export default {
             chainId: 4
           },
           showTorusButton: true,
-          whiteLabel: {
-            theme: {
-              isDark: false,
-              colors: {
-                torusBrand1: '#000000',
-                torusGray2: '#FBF7F3'
-              }
-            },
-            logoDark: 'https://startrail.io/images/front/startrail-top__main.svg', //dark logo for light background
-            logoLight: 'https://s3.amazonaws.com/app.tor.us/startrail-logo-light.svg', //light logo for dark background
-            topupHide: true,
-            featuredBillboardHide: true,
-            tncLink: {
-              "en": 'http://example.com/tnc/en',
-              "ja": 'http://example.com/tnc/ja',
-            },
-            defaultLanguage: 'ja',
-            customTranslations: {
-              "en": {
-                "embed": {
-                  "confirm": "Confirm",
-                  "actionRequired": "Action Required",
-                  "pendingAction": "You have a pending action that needs to be completed in a pop-up window ",
-                  "cookiesRequired": "Cookies Required",
-                  "enableCookies": "Please enable cookies in your browser preferences to access Torus.",
-                  "forMoreInfo": "For more info, ",
-                  "clickHere": "click here",
-                },
-                "login": {
-                  "acceptTerms": "By logging in, you accept Examples'",
-                  "your": "Your",
-                  "digitalWallet": "digital wallet instantly"
-                },
-                "dappTransfer": {
-                  "data": "Data to sign"
-                },
-                "dappPermission": {
-                  "permission": "Permission",
-                  "requestFrom": "Request from",
-                  "accessUserInfo": "To access your Google Email Address, Profile Photo and Name"
-                }
-              },
-              "ja": {
-                "login": {
-                  "acceptTerms": "ログインすると、Examples 'を受け入れます",
-                  "your": "君の",
-                  "digitalWallet": "すぐにデジタルウォレット"
-                },
-                "dappTransfer": {
-                  "data": "あなたがサインするデータ"
-                },
-                "dappPermission": {
-                  "permission": "下記の内容を許可しますか",
-                  "requestFrom": "許可を求めているアプリケーション",
-                  "accessUserInfo": "受け取る情報: Googleメール、プロフィール写真、名前"
-                }
-              }
-            }
-          }
+          // integrity: {
+          //   check: true,
+          //   version: '1.4.2',
+          //   hash: 'sha384-jwXOV6VJu+PM89ksbCSZyQRjf5FdX8n39nWfE/iQBMH2r5m027ua2tkQ+83FPdp9'
+          // }
+          // whiteLabel: {
+          //   theme: {
+          //     isDark: false,
+          //     colors: {
+          //       torusBrand1: '#000000',
+          //       torusGray2: '#FBF7F3'
+          //     }
+          //   },
+          //   logoDark: 'https://startrail.io/images/front/startrail-top__main.svg', //dark logo for light background
+          //   logoLight: 'https://s3.amazonaws.com/app.tor.us/startrail-logo-light.svg', //light logo for dark background
+          //   topupHide: true,
+          //   featuredBillboardHide: true,
+          //   tncLink: {
+          //     "en": 'http://example.com/tnc/en',
+          //     "ja": 'http://example.com/tnc/ja',
+          //   },
+          //   defaultLanguage: 'ja',
+          //   customTranslations: {
+          //     "en": {
+          //       "embed": {
+          //         "confirm": "Confirm",
+          //         "actionRequired": "Action Required",
+          //         "pendingAction": "You have a pending action that needs to be completed in a pop-up window ",
+          //         "cookiesRequired": "Cookies Required",
+          //         "enableCookies": "Please enable cookies in your browser preferences to access Torus.",
+          //         "forMoreInfo": "For more info, ",
+          //         "clickHere": "click here",
+          //       },
+          //       "login": {
+          //         "acceptTerms": "By logging in, you accept Examples'",
+          //         "your": "Your",
+          //         "digitalWallet": "digital wallet instantly"
+          //       },
+          //       "dappTransfer": {
+          //         "data": "Data to sign"
+          //       },
+          //       "dappPermission": {
+          //         "permission": "Permission",
+          //         "requestFrom": "Request from",
+          //         "accessUserInfo": "To access your Google Email Address, Profile Photo and Name"
+          //       }
+          //     },
+          //     "ja": {
+          //       "login": {
+          //         "acceptTerms": "ログインすると、Examples 'を受け入れます",
+          //         "your": "君の",
+          //         "digitalWallet": "すぐにデジタルウォレット"
+          //       },
+          //       "dappTransfer": {
+          //         "data": "あなたがサインするデータ"
+          //       },
+          //       "dappPermission": {
+          //         "permission": "下記の内容を許可しますか",
+          //         "requestFrom": "許可を求めているアプリケーション",
+          //         "accessUserInfo": "受け取る情報: Googleメール、プロフィール写真、名前"
+          //       }
+          //     }
+          //   }
+          // }
         })
         await torus.login() // await torus.ethereum.enable()
         const web3 = new Web3(torus.provider)

--- a/src/utils.js
+++ b/src/utils.js
@@ -147,8 +147,8 @@ export const getTorusUrl = async (buildEnv, integrity) => {
   let logLevel
   let versionUsed = integrity.version || version
   try {
-    if ((buildEnv === 'staging' || buildEnv === 'production') && !integrity.check) {
-      const response = await get(`${config.api}/latestversion?name=${name}&version=${integrity.version || version}`)
+    if ((buildEnv === 'staging' || buildEnv === 'production') && !integrity.version) {
+      const response = await get(`${config.api}/latestversion?name=${name}&version=${version}`)
       versionUsed = response.data
     }
   } catch (error) {


### PR DESCRIPTION
The following changes have been made in this PR:
- Comment example
- Allow arbitrary version to be used without mandating integrity check
(Sometimes dapps want to use an older version without needing to put integrity check. this option enables that. Integrity can still be checked using check: true)