### PR TITLE
Rename _cleanUp to clearInit & make it public

### DIFF
--- a/src/embed.js
+++ b/src/embed.js
@@ -105,11 +105,11 @@ class Torus {
     this.torusWidgetVisibility = showTorusButton
     // Iframe code
     this.torusIframe = htmlToElement(
-      `<iframe 
+      `<iframe
         id="torusIframe"
         class="torusIframe"
         src="${torusUrl}/popup"
-        style="display: none; position: fixed; top: 0; right: 0; width: 100%; 
+        style="display: none; position: fixed; top: 0; right: 0; width: 100%;
         height: 100%; border: none; border-radius: 0; z-index: ${this.modalZIndex}"
       ></iframe>`
     )
@@ -188,7 +188,7 @@ class Torus {
       if (calculatedIntegrity === integrity.hash) {
         await handleSetup()
       } else {
-        this._cleanUp()
+        this.clearInit()
         throw new Error('Integrity check failed')
       }
     } else {
@@ -267,11 +267,10 @@ class Torus {
     if (this.isLoggedIn) {
       await this.logout()
     }
-    this._cleanUp()
+    this.clearInit()
   }
 
-  /** @ignore */
-  _cleanUp() {
+  clearInit() {
     function isElement(element) {
       return element instanceof Element || element instanceof HTMLDocument
     }

--- a/types/embed.d.ts
+++ b/types/embed.d.ts
@@ -85,6 +85,10 @@ declare class Torus {
    * Logs the user out first. Cleans up torus iframe and other assets. Removes torus instance completely
    */
   cleanUp(): Promise<void>
+  /**
+   * Clean up initialized torus client.
+   */
+  clearInit(): Promise<void>
 }
 
 export as namespace Torus
@@ -117,8 +121,8 @@ type LOGIN_TYPE =
 
 interface LoginConfig {
   /**
-   * Use the verifier provided by torus as a key or a default verifier used by torus 
-   * {@link https://docs.tor.us/torus-wallet/developing-with-torus-wallet/oauth | Documentation} 
+   * Use the verifier provided by torus as a key or a default verifier used by torus
+   * {@link https://docs.tor.us/torus-wallet/developing-with-torus-wallet/oauth | Documentation}
    */
   [verifier: string]: LoginConfigItem
 }
@@ -284,7 +288,7 @@ interface TorusParams {
    * development uses https://localhost:3000 (expects torus-website to be run locally),
    *
    * staging uses https://staging.tor.us,
-   * 
+   *
    * lrc uses https://lrc.tor.us,
    *
    * testing uses https://testing.tor.us (latest internal build)
@@ -305,7 +309,7 @@ interface TorusParams {
    */
   showTorusButton?: boolean
   /**
-   * setting false, hides those verifiers from login modal   
+   * setting false, hides those verifiers from login modal
    * @deprecated
    * Please use loginConfig instead
    */


### PR DESCRIPTION
**Is your feature request related to a problem? Please describe.**
Only switching language requires `logout()` when iframe and sessionStorage exist in the browser since init recreation function is not available right now; `cleanUp()` contains `logout()`
It's not critical but I think it would deteriorate UX by forcing user login again for only init param change such as language change.

**Describe the solution you'd like**
It would be better `_cleanUP()` is public.

**Additional context**
Once a user reload the page, iframe and sessionStorage are cleared out which enables user init() without login process as long as the session between iframe and torus remains. 