### PR TITLE
Add sendAsync with web3-core-helpers modules in embed.d.ts

### DIFF
--- a/types/embed.d.ts
+++ b/types/embed.d.ts
@@ -89,8 +89,14 @@ export as namespace Torus
 
 export = Torus
 
+import {
+  JsonRpcPayload,
+  JsonRpcResponse
+} from 'web3-core-helpers'
+
 declare class Provider {
-  send(payload: JsonRPCRequest, callback: Callback<JsonRPCResponse>): any
+  sendAsync(payload: JsonRpcPayload, callback: (error: Error | null, result?: JsonRpcResponse) => void): void;
+  send(payload: JsonRpcPayload, callback: Callback<JsonRpcResponse>): any
 }
 
 type WALLET_PATH = 'transfer' | 'topup' | 'home' | 'settings' | 'history'
@@ -300,7 +306,7 @@ interface TorusParams {
    * staging uses https://staging.tor.us,
    *
    * lrc uses https://lrc.tor.us,
-   * 
+   *
    * beta uses https://beta.tor.us, (currently supports tkey)
    *
    * testing uses https://testing.tor.us (latest internal build)


### PR DESCRIPTION
**Background**
It's not possible to instantiate `Web3` instance with `torusEmbed.provider` in typescript due to the type error. 
`const web3 = new Web3(torus.provider)` emits the error below
![Screenshot 2020-12-01 at 15 10 41](https://user-images.githubusercontent.com/32396386/100703713-67fc9300-33e7-11eb-9303-be48532a9219.png)

**Cause**
Definition of `sendAync` is missing in torus-embed/types/embed.d.ts although Web3 sets it's mandatory in d.ts. 
https://github.com/ethereum/web3.js/blob/1.x/packages/web3-core/types/index.d.ts#L430
 
**What I have done** 
Add `sendAync` in embed.d.ts