### PR TITLE
Set color scheme to none

### DIFF
--- a/src/embed.ts
+++ b/src/embed.ts
@@ -206,7 +206,7 @@ class Torus {
         allow=${useWalletConnect ? "camera" : ""}
         class="torusIframe"
         src="${torusIframeUrl.href}"
-        style="display: none; position: fixed; top: 0; right: 0; width: 100%;
+        style="display: none; position: fixed; top: 0; right: 0; width: 100%; color-scheme: none;
         height: 100%; border: none; border-radius: 0; z-index: ${this.modalZIndex}"
       ></iframe>`
     );


### PR DESCRIPTION
Fixes color-scheme property on Dapps giving torus iframe white background

BEFORE
![Screen Shot 2022-11-11 at 4 18 19 PM](https://user-images.githubusercontent.com/4738957/201296950-680aecf6-ec45-409a-a2c8-b3aa0351e0fb.png)

AFTER
![Screen Shot 2022-11-11 at 4 17 04 PM](https://user-images.githubusercontent.com/4738957/201297018-dd981c4f-0578-4c91-b35d-a7aec285233d.png)
